### PR TITLE
Added paths for chromium

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ gulp dist # build the library
 
 ## Usage
 
+From within a `node` console...
+
 ```
 # Load with a relative path from the root of the node-chrome-runner repo...
 var chrome_runner = require('./build/dist/node-chrome-runner/chrome-runner');
@@ -23,6 +25,11 @@ var c = chrome_runner.runChrome();
 
 # Console log the path used to start chrome...
 console.log(c.path);
+
+# Run with only chromium paths
+var c = chrome_runner.runChrome({
+  versions: [chrome_runner.chromiumPaths]
+});
 
 # Run chrome with a custom path, and argument to make chrome start
 # with user directory `tmp/foo` on Mac...

--- a/src/chrome-runner.ts
+++ b/src/chrome-runner.ts
@@ -48,6 +48,20 @@ export var chromePaths = {
   canary: chromeCanaryPaths
 };
 
+export var chromiumPaths :PlatformPaths = {
+  windowsXp:
+      [path.join(process.env['HOMEPATH'] || '',
+        'Local Settings\\Application Data\\Chromium\\Application\\chromium.exe')],
+  windowsVista:
+      [path.join(process.env['USERPROFILE'] || '',
+        '\\AppData\\Local\\Chromium\\Application\\chromium.exe')],
+  macSystem: ['/Applications/Chromium.app/Contents/MacOS/Chromium'],
+  macUser: [path.join(process.env['HOME'] || '', '/Applications/Chromium.app/Contents/MacOS/Chromium')],
+  linuxSystem: ['/usr/bin/chrome',
+                '/usr/local/bin/chrome',
+                '/opt/bin/chrome'],
+};
+
 // Utility function to pick the first path for chrome that exists in the
 // filesystem (searches in order, lexographically first of version specified,
 // and then for that version for each platform path). Returns null if no path
@@ -83,7 +97,7 @@ export function runChrome(
   var chromePathsForVersions :PlatformPaths[] =
       config.path ? [{ other: [config.path] }]
                   : config.versions
-                    || [chromePaths.stable, chromePaths.canary];
+                    || [chromiumPaths, chromePaths.stable, chromePaths.canary];
   var chosenChromePath = pickFirstPath(chromePathsForVersions);
 
   if (!chosenChromePath) {


### PR DESCRIPTION
Fixes: https://github.com/uProxy/node-chrome-runner/issues/4

TESTED:
- Downloaded chromium from: https://download-chromium.appspot.com/
- installed in chrome binary (chromium) into system path usr/local/bin
- Ran through script

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/node-chrome-runner/7)

<!-- Reviewable:end -->
